### PR TITLE
End crystal, TNT minecart, fire spread, ghast target tracking

### DIFF
--- a/src/main/java/com/mcsunnyside/coreprotecttnt/Main.java
+++ b/src/main/java/com/mcsunnyside/coreprotecttnt/Main.java
@@ -87,8 +87,9 @@ public class Main extends JavaPlugin implements Listener {
                     return;
                 }
             }
+            Location blockCorner = tnt.getLocation().clone().subtract(0.5, 0, 0.5);
             for (Map.Entry<Location, String> entry : ignitedBlocks.entrySet()) {
-                if (entry.getKey().clone().add(0.5, 0, 0.5).distance(tnt.getLocation()) < 0.5) {
+                if (entry.getKey().distance(blockCorner) < 0.5) {
                     set.add(new ExplodeChain(entry.getValue(), tnt));
                     break;
                 }
@@ -250,8 +251,9 @@ public class Main extends JavaPlugin implements Listener {
         }
         if(tnt instanceof ExplosiveMinecart) {
             boolean isLogged = false;
+            Location blockCorner = tnt.getLocation().clone().subtract(0.5, 0, 0.5);
             for (Map.Entry<Location, String> entry : ignitedBlocks.entrySet()) {
-                if (entry.getKey().clone().add(0.5, 0, 0.5).distance(tnt.getLocation()) < 1) {
+                if (entry.getKey().distance(blockCorner) < 1) {
                     for (Block block : blockList) {
                         api.logRemoval("#[MinecartTNT]" + entry.getValue(), block.getLocation(), block.getType(), block.getBlockData());
                         ignitedBlocks.put(block.getLocation(), entry.getValue());

--- a/src/main/java/com/mcsunnyside/coreprotecttnt/Main.java
+++ b/src/main/java/com/mcsunnyside/coreprotecttnt/Main.java
@@ -45,7 +45,7 @@ public class Main extends JavaPlugin implements Listener {
                     ignitedBlocks.clear();
                 }
             }
-        }.runTaskTimerAsynchronously(this, 0, 20 * 60 * 10);
+        }.runTaskTimerAsynchronously(this, 0, 20 * 60);
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,7 +10,12 @@ endercrystal:
 fireball:
   log: true
   disable-when-target-not-found: true
+tntminecart:
+  log: true
+  disable-when-target-not-found: true
 msgs:
   tnt-wont-break-blocks: "§cThis TNT explode won't break any blocks cause it not trigged by player."
   creeper-wont-break-blocks: "§cThis Creeper explode won't break any blocks cause it not trigged by player."
+  endercrystal-wont-break-blocks: "§cThis End Crystal explode won't break any blocks cause it not trigged by player."
   fireball-wont-break-blocks: "§cThis Fireball explode won't break any blocks cause it not trigged by player."
+  tntminecart-wont-break-blocks: "§cThis TNT Minecart explode won't break any blocks cause it not trigged by player."


### PR DESCRIPTION
Sorry for everything in one PR, did it for my friend's server without committing and then realized that I can PR this
What's added:
- End Crystal support (works with enchanted bow, don't know what else can make it explode)
- TNT Minecart support (works with fire and enchanted bow)
- Fire spread tracking (works with player and ghasts)
- Ghast target tracking (logs as `GHAST->PlayerName`). Maybe it would be better to log → instead of -> but I'm not sure if it will be handled properly by CoreProtect on all platforms and on earlier versions
- Chains of all events (e.g. ghast's fireball ignites a tree, the fire spreads to TNT Minecart, it explodes and triggers a bunch of TNTs)
- `HashMap` for tracking ignited blocks
- New `clear`ing strategy (clear when it reaches 1000 entries) because the fire could create thousands of entries in a few minutes. Also applied it for existing `Set<ExplodeChain>` because I couldn't find any memory leaks, so there's no need to clear it unless I missed something (and if I did, it would still clear it). These checks will be performed every minute